### PR TITLE
Update readme and refactor deprecated calls to datatime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
+# Installation
+- You need to have `Python 3.12.0` installed.
+  - If you want to have multiple versions of python on your system, you can use `pyenv`.
+
+## OneDrive Config format:
+- First you need to register an application in your (portal)[https://entra.microsoft.com/].
+  - Go the `Applications->App registrations-> + New registration`.
+  - Go to `Authentication-> + Add a platform -> Mobile and desktop applications`. Put `http://localhost` in the **redirect url** field
+  - Set **Allow public client flows** to **Yes**.
+- Create a config file named `msgraph-parameters.json` inside your `data` folder. Copy the following `json` object and put it the file. Replace `[see your panel]` with your the data shown in your panel.
+
+```json
+{
+    "client_id": "[see your panel]",
+    "tenant_id": "[see your panel]",
+    "authority": "https://login.microsoftonline.com/consumers",
+    "scope": ["User.Read", "files.read.all"]
+}
+``````
+- Run `python onedrive-ingest.py`. You need to sign in to your Mirosoft account and give permissions for reading your files on OneDrive. Follow the instructions on the terminal.
+
 # Test Scripts
 
 These are some test scripts I have written for the Indaleko project.  There's

--- a/onedrive-ingest.py
+++ b/onedrive-ingest.py
@@ -76,7 +76,7 @@ class MicrosoftGraphCredentials:
         return self.__output_file_name__
 
     def get_output_file_name(self):
-        return f'data/microsoft-onedrive-data-{self.get_account_name()}-{datetime.datetime.utcnow()}-data.json'.replace(' ', '_').replace(':', '-')
+        return f'data/microsoft-onedrive-data-{self.get_account_name()}-{datetime.datetime.now(datetime.UTC)}-data.json'.replace(' ', '_').replace(':', '-')
 
     def __get_token__(self):
         if hasattr(self, 'token') and self.token is not None:
@@ -204,10 +204,10 @@ def main():
     parser.add_argument('--reset', action='store_true',
                         default=False, help='Clean database before running')
     args = parser.parse_args()
-    print(args)
-    start = datetime.datetime.utcnow()
+    print("args:", args)
+    start = datetime.datetime.now(datetime.UTC)
     metadata = get_onedrive_metadata_recursive(graphcreds)
-    end = datetime.datetime.utcnow()
+    end = datetime.datetime.now(datetime.UTC)
     if len(metadata) > 0:
         with open(args.output, 'wt') as output_file:
             json.dump(metadata, output_file, indent=4)


### PR DESCRIPTION
- update readme with instructions for setting up OneDrive 
- refactor `onedrive-ingest.py` to use datatime new API